### PR TITLE
fixes variable assignment error/typo in documentation

### DIFF
--- a/documentation/docs/guide/README.md
+++ b/documentation/docs/guide/README.md
@@ -46,8 +46,8 @@ export default {
         publicKey:'pk_test_0000',
         amount:1000, //Expressed in lowest demonitation, so 1000kobo is equivalent to 10Naira
         email:'somteacodes@gmail.com',
-        firstname='Somtea', //optional field remember to pass as a prop of firstname if needed
-        lastname='Codes' //optional field remember to pass as a prop of lastname if needed
+        firstname:'Somtea', //optional field remember to pass as a prop of firstname if needed
+        lastname:'Codes' //optional field remember to pass as a prop of lastname if needed
     }
   },
 


### PR DESCRIPTION
There was a small error in the documentation, that was assigning variables in an object using '=' instead of ':'. This fixes that, and ensures the code snippet on the documentation works when copy/pasted